### PR TITLE
bugfix: comment wrong scaped

### DIFF
--- a/include/system.h
+++ b/include/system.h
@@ -7,6 +7,17 @@
 #include "process.h"
 #include "processor.h"
 
+/**
+ * First Approach: implementd using a pass-thorugh strategy to gather the 
+ * information from linux_parser.
+ * This is not optimal, but has a more simple implementation.
+ * 
+ * Second Approach: 
+ * Initialize once non-dynamic data like Kernel, OS vs. and store in fields
+ * Update dynamic fields, like CPU, memory, processes, etc. once a timeout is 
+ * due, e.g. once per second. Otherwise return stored values.
+ * This will optimice the access to the system files.
+ */
 class System {
  public:
   Processor& Cpu();                   // TODO: See src/system.cpp


### PR DESCRIPTION
A class description comment wasn't escaped properly.